### PR TITLE
Fixed MQ sleuth modules bugs, added MQ sleuth example

### DIFF
--- a/examples/sleuth-invoke1-example/pom.xml
+++ b/examples/sleuth-invoke1-example/pom.xml
@@ -31,6 +31,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>com.tairanchina.csp.dew</groupId>
+            <artifactId>cluster-spi-rabbit</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/examples/sleuth-invoke1-example/src/main/java/com/tairanchina/csp/dew/example/sleuth/SleuthExampleController.java
+++ b/examples/sleuth-invoke1-example/src/main/java/com/tairanchina/csp/dew/example/sleuth/SleuthExampleController.java
@@ -1,5 +1,6 @@
 package com.tairanchina.csp.dew.example.sleuth;
 
+import com.tairanchina.csp.dew.Dew;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -28,6 +29,13 @@ public class SleuthExampleController {
     public String ping(@RequestParam("code") String code) throws InterruptedException {
         logger.info("ssss");
         return restTemplate.getForObject("http://sleuth-invoke2-example/ping?code=" + code, String.class);
+    }
+
+    @GetMapping("pingmq")
+    public String pingmq(@RequestParam("code") String code) throws InterruptedException {
+        logger.info("测试MQ的Sleuth");
+        boolean publish = Dew.cluster.mq.publish("test712", "message712");
+        return publish+"";
     }
 
     @GetMapping("pong")

--- a/examples/sleuth-invoke1-example/src/main/resources/bootstrap.yml
+++ b/examples/sleuth-invoke1-example/src/main/resources/bootstrap.yml
@@ -4,9 +4,25 @@ spring:
   cloud:
     config:
       enabled: false
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+    virtual-host: /li
+
 server:
   port: 8081
 eureka:
   client:
     serviceUrl:
       defaultZone:  http://registry:123456@localhost:9999/eureka
+    eureka-server-read-timeout-seconds: 100
+
+
+dew:
+  cluster:
+    cache: redis
+    dist: redis # 可选 redis/hazelcast
+    mq: rabbit # 可选 redis/hazelcast/rabbit
+    election: eureka

--- a/examples/sleuth-invoke2-example/pom.xml
+++ b/examples/sleuth-invoke2-example/pom.xml
@@ -31,6 +31,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>com.tairanchina.csp.dew</groupId>
+            <artifactId>cluster-spi-rabbit</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/examples/sleuth-invoke2-example/src/main/java/com/tairanchina/csp/dew/example/sleuth/SleuthExampleApplication.java
+++ b/examples/sleuth-invoke2-example/src/main/java/com/tairanchina/csp/dew/example/sleuth/SleuthExampleApplication.java
@@ -1,16 +1,30 @@
 package com.tairanchina.csp.dew.example.sleuth;
 
 
+import com.tairanchina.csp.dew.Dew;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.client.SpringCloudApplication;
 import org.springframework.cloud.netflix.feign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
 
 @SpringCloudApplication
 @EnableFeignClients
+@Configuration
 public class SleuthExampleApplication  {
+
+    private Logger logger = LoggerFactory.getLogger(SleuthExampleApplication.class);
 
     public static void main(String[] args) {
         new SpringApplicationBuilder(SleuthExampleApplication.class).run(args);
     }
 
+    @PostConstruct
+    public void init(){
+        logger.info("开始监听.." );
+        Dew.cluster.mq.subscribe("test712", message -> logger.info("pub_sub->{}" , message));
+    }
 }

--- a/examples/sleuth-invoke2-example/src/main/resources/bootstrap.yml
+++ b/examples/sleuth-invoke2-example/src/main/resources/bootstrap.yml
@@ -4,6 +4,13 @@ spring:
   cloud:
     config:
       enabled: false
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+    virtual-host: /li
+
 
 server:
   port: 8082
@@ -12,3 +19,13 @@ eureka:
   client:
     serviceUrl:
       defaultZone:  http://registry:123456@localhost:9999/eureka
+    eureka-server-read-timeout-seconds: 100
+
+
+
+dew:
+  cluster:
+    cache: redis
+    dist: redis # 可选 redis/hazelcast
+    mq: rabbit # 可选 redis/hazelcast/rabbit
+    election: eureka

--- a/examples/sleuth-invoke3-example/src/main/java/com/tairanchina/csp/dew/example/sleuth/SleuthExampleController.java
+++ b/examples/sleuth-invoke3-example/src/main/java/com/tairanchina/csp/dew/example/sleuth/SleuthExampleController.java
@@ -20,7 +20,13 @@ public class SleuthExampleController {
     @PostMapping("ping")
     public String ping(@RequestBody SomeVO vo) {
         logger.info("收到请求");
-        return sleuthInvoke1Client.pong(vo.code);
+        try {
+            String pong = sleuthInvoke1Client.pong(vo.code);
+            logger.info("pong={}",pong);
+        }catch (Exception e){
+            logger.error("err",e);
+        }
+        return "rest";
     }
 
     public static class SomeVO {

--- a/examples/sleuth-invoke3-example/src/main/resources/bootstrap.yml
+++ b/examples/sleuth-invoke3-example/src/main/resources/bootstrap.yml
@@ -12,3 +12,4 @@ eureka:
   client:
     serviceUrl:
       defaultZone:  http://registry:123456@localhost:9999/eureka
+    eureka-server-read-timeout-seconds: 100

--- a/modules/cloud-starter/src/main/java/com/tairanchina/csp/dew/core/logger/SleuthLogConfiguration.java
+++ b/modules/cloud-starter/src/main/java/com/tairanchina/csp/dew/core/logger/SleuthLogConfiguration.java
@@ -29,7 +29,7 @@ public class SleuthLogConfiguration {
             Cluster.initMQHeader(name -> {
                 Span span = tracer.createSpan(name);
                 Long parentId = !span.getParents().isEmpty() ? span.getParents().get(0) : null;
-                return new HashMap<String, Object>() {{
+                HashMap<String, Object> hashMap = new HashMap<String, Object>() {{
                     put(TraceMessageHeaders.TRACE_ID_NAME, Span.idToHex(span.getTraceId()));
                     put(TraceMessageHeaders.SPAN_ID_NAME, Span.idToHex(span.getSpanId()));
                     put(TraceMessageHeaders.SPAN_NAME_NAME, span.getName());
@@ -38,25 +38,27 @@ public class SleuthLogConfiguration {
                         put(Span.PARENT_ID_NAME, Span.idToHex(parentId));
                     }
                 }};
+                tracer.detach(span);
+                return hashMap;
             }, headerWithName -> {
                 String name = (String) headerWithName[0];
                 Map<String, Object> header = (Map<String, Object>) headerWithName[1];
                 if (header == null || header.isEmpty()) {
                     return;
                 }
-                String traceId = header.containsKey(TraceMessageHeaders.TRACE_ID_NAME) ? (String) header.get(TraceMessageHeaders.TRACE_ID_NAME) : null;
+                String traceId = header.containsKey(TraceMessageHeaders.TRACE_ID_NAME) ? String.valueOf(header.get(TraceMessageHeaders.TRACE_ID_NAME)) : null;
                 if (traceId == null) {
                     tracer.createSpan(name);
                 } else {
                     Span.SpanBuilder spanBuilder = Span.builder();
-                    String spanId = header.containsKey(TraceMessageHeaders.SPAN_ID_NAME) ? (String) header.get(TraceMessageHeaders.SPAN_ID_NAME) : traceId;
+                    String spanId = header.containsKey(TraceMessageHeaders.SPAN_ID_NAME) ? String.valueOf(header.get(TraceMessageHeaders.SPAN_ID_NAME)) : traceId;
                     spanBuilder
                             .traceIdHigh(traceId.length() == 32 ? Span.hexToId(traceId, 0) : 0)
                             .traceId(Span.hexToId(traceId))
                             .spanId(Span.hexToId(spanId));
-                    String processId = header.containsKey(TraceMessageHeaders.PROCESS_ID_NAME) ? (String) header.get(TraceMessageHeaders.PROCESS_ID_NAME) : null;
-                    String spanName = header.containsKey(TraceMessageHeaders.SPAN_NAME_NAME) ? (String) header.get(TraceMessageHeaders.SPAN_NAME_NAME) : null;
-                    String parentId = header.containsKey(TraceMessageHeaders.PARENT_ID_NAME) ? (String) header.get(TraceMessageHeaders.PARENT_ID_NAME) : null;
+                    String processId = header.containsKey(TraceMessageHeaders.PROCESS_ID_NAME) ? String.valueOf(header.get(TraceMessageHeaders.PROCESS_ID_NAME)) : null;
+                    String spanName = header.containsKey(TraceMessageHeaders.SPAN_NAME_NAME) ? String.valueOf(header.get(TraceMessageHeaders.SPAN_NAME_NAME)) : null;
+                    String parentId = header.containsKey(TraceMessageHeaders.PARENT_ID_NAME) ? String.valueOf(header.get(TraceMessageHeaders.PARENT_ID_NAME)) : null;
                     if (processId != null) {
                         spanBuilder.processId(processId);
                     }


### PR DESCRIPTION
#12 
fixed some bugs:

Cast to String change to String.valueOf()
```java
String spanId = header.containsKey(TraceMessageHeaders.SPAN_ID_NAME) ? String.valueOf(header.get(TraceMessageHeaders.SPAN_ID_NAME)) : traceId;
```

tracer must be detach before return, use tracer.detach(span);

```java
Span span = tracer.createSpan(name);
Long parentId = !span.getParents().isEmpty() ? span.getParents().get(0) : null;
HashMap<String, Object> hashMap = new HashMap<String, Object>() {{
    put(TraceMessageHeaders.TRACE_ID_NAME, Span.idToHex(span.getTraceId()));
    put(TraceMessageHeaders.SPAN_ID_NAME, Span.idToHex(span.getSpanId()));
    put(TraceMessageHeaders.SPAN_NAME_NAME, span.getName());
    put(TraceMessageHeaders.PROCESS_ID_NAME, span.getProcessId());
    if (parentId != null) {
        put(Span.PARENT_ID_NAME, Span.idToHex(parentId));
    }
}};
tracer.detach(span);
return hashMap;
```

MQ sleuth example is in sleuth-invoke1-example and sleuth-invoke2-example
run these examples and  request **localhost:8081/pingmq**
