### PR TITLE
 Add refresh mojo & Upgrade kubernetes client-java version.

### DIFF
--- a/devops/maven/dew-maven-plugin/pom.xml
+++ b/devops/maven/dew-maven-plugin/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
-            <version>4.0.0</version>
+            <version>5.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/flow/refresh/DefaultRefreshFlow.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/flow/refresh/DefaultRefreshFlow.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ms.dew.devops.kernel.flow.refresh;
+
+import io.kubernetes.client.ApiException;
+import io.kubernetes.client.models.*;
+import ms.dew.devops.kernel.config.FinalProjectConfig;
+import ms.dew.devops.kernel.flow.BasicFlow;
+import ms.dew.devops.kernel.helper.KubeHelper;
+import ms.dew.devops.kernel.helper.KubeRES;
+import ms.dew.devops.kernel.resource.KubeDeploymentBuilder;
+
+import java.io.IOException;
+import java.util.*;
+
+public class DefaultRefreshFlow extends BasicFlow {
+
+    @Override
+    protected void process(FinalProjectConfig config, String flowBasePath) throws ApiException, IOException {
+
+        logger.info("Restarting pods ... ");
+        KubeHelper.inst(config.getId()).patch(config.getAppName(), new ArrayList<String>() {
+            {
+                List<ExtensionsV1beta1Deployment> deploymentList = KubeHelper.inst(
+                        config.getId()).list("app=" + config.getAppName(), config.getNamespace(),
+                        KubeRES.DEPLOYMENT, ExtensionsV1beta1Deployment.class);
+
+                for (ExtensionsV1beta1Deployment deployment : deploymentList) {
+                    if (config.getAppName().equals(deployment.getMetadata().getName())) {
+                        deployment.getSpec().getTemplate().getSpec().getContainers().forEach(c -> {
+                                    if (c.getName().equals(KubeDeploymentBuilder.FLAG_CONTAINER_NAME)) {
+                                        if (c.getEnv() == null || c.getEnv().isEmpty()) {
+                                            add("{ \"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/env\", " +
+                                                    "\"value\": [{\"name\":\"DEW_RESTART_DATE\",\"value\":\"" + new Date() + "\"}] }");
+                                        } else {
+                                            add("{ \"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/env/0\", " +
+                                                    "\"value\": {\"name\":\"DEW_RESTART_DATE\",\"value\":\"" + new Date() + "\"} }");
+                                        }
+                                    }
+                                }
+                        );
+                    }
+                }
+            }
+        }, config.getNamespace(), KubeRES.DEPLOYMENT);
+    }
+}

--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/flow/refresh/DefaultRefreshFlow.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/flow/refresh/DefaultRefreshFlow.java
@@ -27,6 +27,11 @@ import ms.dew.devops.kernel.resource.KubeDeploymentBuilder;
 import java.io.IOException;
 import java.util.*;
 
+/**
+ * Default refresh flow.
+ *
+ * @author Sun
+ */
 public class DefaultRefreshFlow extends BasicFlow {
 
     @Override
@@ -44,11 +49,11 @@ public class DefaultRefreshFlow extends BasicFlow {
                         deployment.getSpec().getTemplate().getSpec().getContainers().forEach(c -> {
                                     if (c.getName().equals(KubeDeploymentBuilder.FLAG_CONTAINER_NAME)) {
                                         if (c.getEnv() == null || c.getEnv().isEmpty()) {
-                                            add("{ \"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/env\", " +
-                                                    "\"value\": [{\"name\":\"DEW_RESTART_DATE\",\"value\":\"" + new Date() + "\"}] }");
+                                            add("{ \"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/env\", "
+                                                    + "\"value\": [{\"name\":\"DEW_RESTART_DATE\",\"value\":\"" + new Date() + "\"}] }");
                                         } else {
-                                            add("{ \"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/env/0\", " +
-                                                    "\"value\": {\"name\":\"DEW_RESTART_DATE\",\"value\":\"" + new Date() + "\"} }");
+                                            add("{ \"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/env/0\", "
+                                                    + "\"value\": {\"name\":\"DEW_RESTART_DATE\",\"value\":\"" + new Date() + "\"} }");
                                         }
                                     }
                                 }

--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/function/ExecuteEventProcessor.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/function/ExecuteEventProcessor.java
@@ -65,6 +65,7 @@ public class ExecuteEventProcessor {
                 && !mojoName.equalsIgnoreCase("rollback")
                 && !mojoName.equalsIgnoreCase("scale")
                 && !mojoName.equalsIgnoreCase("unrelease")
+                && !mojoName.equalsIgnoreCase("refresh")
         ) {
             return;
         }
@@ -137,6 +138,7 @@ public class ExecuteEventProcessor {
                             || project.getExecuteSuccessfulMojos().contains("rollback")
                             || project.getExecuteSuccessfulMojos().contains("scale")
                             || project.getExecuteSuccessfulMojos().contains("unrelease")
+                            || project.getExecuteSuccessfulMojos().contains("refresh")
                     ).collect(Collectors.toList());
             List<FinalProjectConfig> nonExecutionProjects =
                     projects.values().stream()

--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/helper/KubeOpt.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/helper/KubeOpt.java
@@ -687,7 +687,7 @@ public class KubeOpt {
      * @param namespace the namespace
      * @param res       the res
      * @throws ApiException the api exception
-     * @link http ://jsonpatch.com/
+     * @link http://jsonpatch.com/
      */
     public void patch(String name, List<String> patchers, String namespace, KubeRES res) throws ApiException {
         List<JsonObject> jsonPatchers = patchers.stream()
@@ -961,63 +961,63 @@ public class KubeOpt {
             switch (res) {
                 case NAME_SPACE:
                     coreApi.deleteNamespace(
-                            name, deleteOptions, null, null, null, null, null);
+                            name, "true", deleteOptions, null, null, null, null);
                     break;
                 case INGRESS:
                     extensionsApi.deleteNamespacedIngress(
-                            name, namespace, deleteOptions, "true", null, null, null, null);
+                            name, namespace, "true", deleteOptions, null, null, null, null);
                     break;
                 case SERVICE:
                     coreApi.deleteNamespacedService(
-                            name, namespace, deleteOptions, "true", null, null, null, null);
+                            name, namespace, "true", deleteOptions, null, null, null, null);
                     break;
                 case DEPLOYMENT:
                     extensionsApi.deleteNamespacedDeployment(
-                            name, namespace, deleteOptions, "true", null, null, null, null);
+                            name, namespace, "true", deleteOptions, null, null, null, null);
                     break;
                 case REPLICA_SET:
                     extensionsApi.deleteNamespacedReplicaSet(
-                            name, namespace, deleteOptions, "true", null, null, null, null);
+                            name, namespace, "true", deleteOptions, null, null, null, null);
                     break;
                 case POD:
                     coreApi.deleteNamespacedPod(
-                            name, namespace, deleteOptions, "true", null, null, null, null);
+                            name, namespace, "true", deleteOptions, null, null, null, null);
                     break;
                 case SECRET:
                     coreApi.deleteNamespacedSecret(
-                            name, namespace, deleteOptions, "true", null, null, null, null);
+                            name, namespace, "true", deleteOptions, null, null, null, null);
                     break;
                 case CONFIG_MAP:
                     coreApi.deleteNamespacedConfigMap(
-                            name, namespace, deleteOptions, "true", null, null, null, null);
+                            name, namespace, "true", deleteOptions, null, null, null, null);
                     break;
                 case SERVICE_ACCOUNT:
                     coreApi.deleteNamespacedServiceAccount(
-                            name, namespace, deleteOptions, "true", null, null, null, null);
+                            name, namespace, "true", deleteOptions, null, null, null, null);
                     break;
                 case DAEMON_SET:
                     extensionsApi.deleteNamespacedDaemonSet(
-                            name, namespace, deleteOptions, "true", null, null, null, null);
+                            name, namespace, "true", deleteOptions, null, null, null, null);
                     break;
                 case ROLE:
                     rbacAuthorizationApi.deleteNamespacedRole(
-                            name, namespace, deleteOptions, "true", null, null, null, null);
+                            name, namespace, "true", deleteOptions, null, null, null, null);
                     break;
                 case ROLE_BINDING:
                     rbacAuthorizationApi.deleteNamespacedRoleBinding(
-                            name, namespace, deleteOptions, "true", null, null, null, null);
+                            name, namespace, "true", deleteOptions, null, null, null, null);
                     break;
                 case CLUSTER_ROLE:
                     rbacAuthorizationApi.deleteClusterRole(
-                            name, deleteOptions, "true", null, null, null, null);
+                            name, "true", deleteOptions, null, null, null, null);
                     break;
                 case CLUSTER_ROLE_BINDING:
                     rbacAuthorizationApi.deleteClusterRoleBinding(
-                            name, deleteOptions, "true", null, null, null, null);
+                            name, "true", deleteOptions, null, null, null, null);
                     break;
                 case HORIZONTAL_POD_AUTOSCALER:
                     autoscalingApi.deleteNamespacedHorizontalPodAutoscaler(
-                            name, namespace, deleteOptions, "true", null, null, null, null);
+                            name, namespace, "true", deleteOptions, null, null, null, null);
                     break;
                 default:
                     throw new ApiException("The resource [" + res.getVal() + "] operation NOT implementation");

--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/plugin/appkind/AppKindPlugin.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/plugin/appkind/AppKindPlugin.java
@@ -64,35 +64,42 @@ public interface AppKindPlugin {
     BasicFlow releaseFlow();
 
     /**
-     * Release flow basic flow.
+     * UnRelease flow basic flow.
      *
      * @return the basic flow
      */
     BasicFlow unReleaseFlow();
 
     /**
-     * Release flow basic flow.
+     * Rollback flow basic flow.
      *
      * @return the basic flow
      */
     BasicFlow rollbackFlow();
 
     /**
-     * Release flow basic flow.
+     * Scale flow basic flow.
      *
      * @return the basic flow
      */
     BasicFlow scaleFlow(int replicas, boolean autoScale, int minReplicas, int maxReplicas, int cpuAvg);
 
     /**
-     * Release flow basic flow.
+     * Refresh flow basic flow.
+     *
+     * @return the basic flow
+     */
+    BasicFlow refreshFlow();
+
+    /**
+     * Log flow basic flow.
      *
      * @return the basic flow
      */
     BasicFlow logFlow(String podName, boolean follow);
 
     /**
-     * Release flow basic flow.
+     * Debug flow basic flow.
      *
      * @return the basic flow
      */

--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/plugin/appkind/frontend_node/FrontendNodeAppKindPlugin.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/plugin/appkind/frontend_node/FrontendNodeAppKindPlugin.java
@@ -20,6 +20,7 @@ import ms.dew.devops.kernel.config.FinalProjectConfig;
 import ms.dew.devops.kernel.flow.BasicFlow;
 import ms.dew.devops.kernel.flow.NoNeedProcessFLow;
 import ms.dew.devops.kernel.flow.log.DefaultLogFlow;
+import ms.dew.devops.kernel.flow.refresh.DefaultRefreshFlow;
 import ms.dew.devops.kernel.flow.release.KubeReleaseFlow;
 import ms.dew.devops.kernel.flow.rollback.DefaultRollbackFlow;
 import ms.dew.devops.kernel.flow.scale.DefaultScaleFlow;
@@ -83,6 +84,11 @@ public class FrontendNodeAppKindPlugin implements AppKindPlugin {
     @Override
     public BasicFlow scaleFlow(int replicas, boolean autoScale, int minReplicas, int maxReplicas, int cpuAvg) {
         return new DefaultScaleFlow(replicas, autoScale, minReplicas, maxReplicas, cpuAvg);
+    }
+
+    @Override
+    public BasicFlow refreshFlow() {
+        return new DefaultRefreshFlow();
     }
 
     @Override

--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/plugin/appkind/jvmlib/JvmLibAppKindPlugin.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/plugin/appkind/jvmlib/JvmLibAppKindPlugin.java
@@ -78,6 +78,11 @@ public class JvmLibAppKindPlugin implements AppKindPlugin {
     }
 
     @Override
+    public BasicFlow refreshFlow() {
+        return new NoNeedProcessFLow();
+    }
+
+    @Override
     public BasicFlow logFlow(String podName, boolean follow) {
         return new NoNeedProcessFLow();
     }

--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/plugin/appkind/jvmservice_springboot/JvmServiceSpringBootAppKindPlugin.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/plugin/appkind/jvmservice_springboot/JvmServiceSpringBootAppKindPlugin.java
@@ -22,6 +22,7 @@ import ms.dew.devops.kernel.config.FinalProjectConfig;
 import ms.dew.devops.kernel.flow.BasicFlow;
 import ms.dew.devops.kernel.flow.debug.DefaultDebugFlow;
 import ms.dew.devops.kernel.flow.log.DefaultLogFlow;
+import ms.dew.devops.kernel.flow.refresh.DefaultRefreshFlow;
 import ms.dew.devops.kernel.flow.release.KubeReleaseFlow;
 import ms.dew.devops.kernel.flow.rollback.DefaultRollbackFlow;
 import ms.dew.devops.kernel.flow.scale.DefaultScaleFlow;
@@ -144,6 +145,11 @@ public class JvmServiceSpringBootAppKindPlugin implements AppKindPlugin {
     @Override
     public BasicFlow scaleFlow(int replicas, boolean autoScale, int minReplicas, int maxReplicas, int cpuAvg) {
         return new DefaultScaleFlow(replicas, autoScale, minReplicas, maxReplicas, cpuAvg);
+    }
+
+    @Override
+    public BasicFlow refreshFlow() {
+        return new DefaultRefreshFlow();
     }
 
     @Override

--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/plugin/appkind/pom/PomAppKindPlugin.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/plugin/appkind/pom/PomAppKindPlugin.java
@@ -78,6 +78,11 @@ public class PomAppKindPlugin implements AppKindPlugin {
     }
 
     @Override
+    public BasicFlow refreshFlow() {
+        return new NoNeedProcessFLow();
+    }
+
+    @Override
     public BasicFlow logFlow(String podName, boolean follow) {
         return new NoNeedProcessFLow();
     }

--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/maven/mojo/RefreshMojo.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/maven/mojo/RefreshMojo.java
@@ -22,6 +22,11 @@ import org.apache.maven.plugins.annotations.Mojo;
 
 import java.io.IOException;
 
+/**
+ * Default refresh flow.
+ *
+ * @author Sun
+ */
 @Mojo(name = "refresh")
 public class RefreshMojo extends BasicMojo {
     @Override

--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/maven/mojo/RefreshMojo.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/maven/mojo/RefreshMojo.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ms.dew.devops.maven.mojo;
+
+import io.kubernetes.client.ApiException;
+import ms.dew.devops.kernel.DevOps;
+import org.apache.maven.plugins.annotations.Mojo;
+
+import java.io.IOException;
+
+@Mojo(name = "refresh")
+public class RefreshMojo extends BasicMojo {
+    @Override
+    protected boolean executeInternal() throws IOException, ApiException {
+        return DevOps.Config.getProjectConfig(mavenProject.getId()).getAppKindPlugin()
+                .refreshFlow().exec(mavenProject.getId(), getMojoName());
+    }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -531,9 +531,10 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#应用卸载">4.2.7. 应用卸载</a></li>
 <li><a href="#日志查看">4.2.8. 日志查看</a></li>
 <li><a href="#伸缩扩展">4.2.9. 伸缩扩展</a></li>
-<li><a href="#ci_cd工具支持_gitlab_ci">4.2.10. CI/CD工具支持-Gitlab CI</a></li>
-<li><a href="#执行通知">4.2.11. 执行通知</a></li>
-<li><a href="#监控管理">4.2.12. 监控管理</a></li>
+<li><a href="#应用刷新">4.2.10. 应用刷新</a></li>
+<li><a href="#ci_cd工具支持_gitlab_ci">4.2.11. CI/CD工具支持-Gitlab CI</a></li>
+<li><a href="#执行通知">4.2.12. 执行通知</a></li>
+<li><a href="#监控管理">4.2.13. 监控管理</a></li>
 </ul>
 </li>
 <li><a href="#devops-env-install">4.3. 测试、生产环境安装配置</a>
@@ -4879,7 +4880,20 @@ mvn dew:scale
 </div>
 </div>
 <div class="sect3">
-<h4 id="ci_cd工具支持_gitlab_ci"><a class="anchor" href="#ci_cd工具支持_gitlab_ci"></a>4.2.10. CI/CD工具支持-Gitlab CI</h4>
+<h4 id="应用刷新"><a class="anchor" href="#应用刷新"></a>4.2.10. 应用刷新</h4>
+<div class="paragraph">
+<p>用于刷新重启某一个应用，此命令在要重启的应用目录下执行。</p>
+</div>
+<div class="listingblock">
+<div class="title">命令</div>
+<div class="content">
+<pre class="prettyprint highlight"><code class="language-bash" data-lang="bash"># 基础命令
+mvn dew:refresh</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="ci_cd工具支持_gitlab_ci"><a class="anchor" href="#ci_cd工具支持_gitlab_ci"></a>4.2.11. CI/CD工具支持-Gitlab CI</h4>
 <div class="paragraph">
 <p>应用的部署与回滚为 <code>DevOps</code> 的核心操作，这些操作应该与 <code>CI/CD</code> 工具集成使用。</p>
 </div>
@@ -4940,7 +4954,7 @@ prod deploy:
 </div>
 </div>
 <div class="sect3">
-<h4 id="执行通知"><a class="anchor" href="#执行通知"></a>4.2.11. 执行通知</h4>
+<h4 id="执行通知"><a class="anchor" href="#执行通知"></a>4.2.12. 执行通知</h4>
 <div class="paragraph">
 <p>目前支持 <code>钉钉</code> 与 <code>HTTP</code> 两种方式：</p>
 </div>
@@ -5044,7 +5058,7 @@ prod deploy:
 </div>
 </div>
 <div class="sect3">
-<h4 id="监控管理"><a class="anchor" href="#监控管理"></a>4.2.12. 监控管理</h4>
+<h4 id="监控管理"><a class="anchor" href="#监控管理"></a>4.2.13. 监控管理</h4>
 
 </div>
 </div>
@@ -9160,7 +9174,7 @@ prod deploy: # 生产环境部署
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-06-14 15:01:55 CST
+Last updated 2019-06-17 16:48:39 CST
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.css">

--- a/docs/src/main/asciidoc/_chapter/devops/user-manual.adoc
+++ b/docs/src/main/asciidoc/_chapter/devops/user-manual.adoc
@@ -298,6 +298,18 @@ mvn dew:scale
 
 NOTE: ``dew_devops_scale_auto: false``（默认情况） 时 ``dew_devops_scale_replicas`` 为必要参数，反之另几个参数为必要参数。
 
+==== 应用刷新
+
+用于刷新重启某一个应用，此命令在要重启的应用目录下执行。
+
+.命令
+
+[source,bash]
+----
+# 基础命令
+mvn dew:refresh
+----
+
 ==== CI/CD工具支持-Gitlab CI
 
 应用的部署与回滚为 ``DevOps`` 的核心操作，这些操作应该与 ``CI/CD`` 工具集成使用。


### PR DESCRIPTION
#109 
为了保证项目的滚动更新和滚动刷新重启时，服务都能处于正常运行状态，建议副本数设为2以上。
To ensure the  rolling update of  your application when refreshing or deploying,it‘s recommended to set the number of your replicas 2 or more.  

TIP:
K8S  V1.15将会支持通过kubectl来滚动重启Replication Controller。
In Kubernetes V1.15 ,it will support using the `kubectl` to do a rolling restart,like this:
`kubectl rollout restart deployment/$deployment`
 