### PR TITLE
Support custom container command.

### DIFF
--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/config/DewApp.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/config/DewApp.java
@@ -89,6 +89,8 @@ public class DewApp {
     private String serverConfig;
     // 运行参数，可指定诸如 JVM 配置等信息
     private String runOptions;
+    // 容器command命令
+    private List<String> containerCmd;
     // 容器资源上限，同Kubernetes配置
     // @see  https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     private Map<String, Quantity> containerResourcesLimits = new HashMap<>();
@@ -562,6 +564,24 @@ public class DewApp {
      */
     public void setRunOptions(String runOptions) {
         this.runOptions = runOptions;
+    }
+
+    /**
+     * Gets container command.
+     *
+     * @return the container command
+     */
+    public List<String> getContainerCmd() {
+        return containerCmd;
+    }
+
+    /**
+     * Sets container command.
+     *
+     * @param containerCmd the container command
+     */
+    public void setContainerCmd(List<String> containerCmd) {
+        this.containerCmd = containerCmd;
     }
 
     /**

--- a/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/resource/KubeDeploymentBuilder.java
+++ b/devops/maven/dew-maven-plugin/src/main/java/ms/dew/devops/kernel/resource/KubeDeploymentBuilder.java
@@ -84,6 +84,7 @@ public class KubeDeploymentBuilder implements KubeResourceBuilder<ExtensionsV1be
         }
 
         V1ContainerBuilder containerBuilder = new V1ContainerBuilder()
+                .withCommand(config.getApp().getContainerCmd())
                 .withName(FLAG_CONTAINER_NAME)
                 .withImage(config.getCurrImageName())
                 .withImagePullPolicy("IfNotPresent")

--- a/docs/index.html
+++ b/docs/index.html
@@ -6537,6 +6537,7 @@ app:                                    # 应用配置
                                         # 后端服务默认为空
   runOptions:                           # 运行参数，可指定诸如 JVM 配置等信息
   serverConfig: |-                      # 服务配置，多为Nginx配置
+  containerCmd: []                      # 容器command命令
   containerResourcesLimits: {}          # 容器资源上限，同Kubernetes配置，值应大于等于containerResourcesRequests
                                         # @see  https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
   containerResourcesRequests: {}        # 容器资源下限，同Kubernetes配置，值应小于等于containerResourcesLimits

--- a/docs/src/main/asciidoc/_chapter/devops/configuration.adoc
+++ b/docs/src/main/asciidoc/_chapter/devops/configuration.adoc
@@ -56,6 +56,7 @@ app:                                    # 应用配置
                                         # 后端服务默认为空
   runOptions:                           # 运行参数，可指定诸如 JVM 配置等信息
   serverConfig: |-                      # 服务配置，多为Nginx配置
+  containerCmd: []                      # 容器command命令
   containerResourcesLimits: {}          # 容器资源上限，同Kubernetes配置，值应大于等于containerResourcesRequests
                                         # @see  https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
   containerResourcesRequests: {}        # 容器资源下限，同Kubernetes配置，值应小于等于containerResourcesLimits


### PR DESCRIPTION
支持自定义容器command。

使用场景举例：
若Dockerfile中未定义CMD或ENTRYPOINT时，部分项目的pod无法正常启动，可以通过设置容器的command来使pod正常运行。
```
app:
  containerCmd: []
```
否则需要修改该项目的Dockerfile或底层镜像才能正常启动。